### PR TITLE
add constant time compare function to mitigate timing attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Hash Password Example:
 	            
     //validate user
     //compare the password (this should be true since we are rehashing the same password and using the same generated salt)
-    bool isPasswordValid = cryptoService.Compute(password, salt) == hashedPassword;
+    string hashedPassword2 = cryptoService.Compute(password, salt);
+    bool isPasswordValid = cryptoService.Compare(hashedPassword, hashedPassword2);
 
 Generate Random Password Example:
 

--- a/src/Interfaces/ICryptoService.cs
+++ b/src/Interfaces/ICryptoService.cs
@@ -86,5 +86,12 @@ namespace SimpleCrypto
         /// <param name="iteration"></param>
         /// <returns></returns>
         int GetElapsedTimeForIteration(int iteration);
+        
+        /// <summary>
+        /// Compare the passwords for equality
+        /// <param name="passwordHash1">The first password hash to compare</param>
+        /// <param name="passwordHash2">The second password hash to compare</param>
+        /// <returns>true: indicating the password hashes are the same, false otherwise.</param>
+        bool Compare(string passwordHash1, string passwordHash2);
     }
 }

--- a/src/PBKDF2.cs
+++ b/src/PBKDF2.cs
@@ -208,6 +208,24 @@ namespace SimpleCrypto
             }
         }
 
+        /// <summary>
+        /// Compare password hashes for equality. Uses a constant time comparison method.
+        /// </summary>
+        /// <param name="passwordHash1"></param>
+        /// <param name="passwordHash2"></param>
+        /// <returns></returns>
+        public bool Compare(string passwordHash1, string passwordHash2)
+        {
+            if (passwordHash1 == null || passwordHash2 == null)
+                return false;
 
+            int min_length = Math.Min(passwordHash1.Length, passwordHash2.Length);
+            int result = 0;
+
+            for(int i = 0; i < min_length; i++)
+                result |= passwordHash1[i] ^ passwordHash2[i];
+
+            return 0 == result;
+        }
     }
 }

--- a/tests/PBKDF2Tests.cs
+++ b/tests/PBKDF2Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using NUnit.Framework;
 
 namespace SimpleCrypto.Tests
@@ -163,6 +164,22 @@ namespace SimpleCrypto.Tests
             var salt = crypto.GenerateSalt();
 
             Assert.AreEqual(crypto.Salt, salt, "The returned salt is not the salt set as parameter");
+        }
+
+        [Test]
+        public void Comparison_To_Same_Hash_Returns_True()
+        {
+            var crypto = CreateICryptoService();
+
+            var hash1 = crypto.Compute("password");
+            var salt = crypto.Salt;
+
+            var hash2 = crypto.Compute("password", salt);
+
+            Assert.IsTrue(crypto.Compare(hash1, hash2), "Hash comparison fails");
+
+            var hash3 = crypto.Compute("pasw1rd", salt);
+            Assert.IsFalse(crypto.Compare(hash1, hash3), "Hash comparison should fail but didn't");
         }
     }
 }


### PR DESCRIPTION
My first take at constant time comparison.

perhaps this could be easier to use if there was another function such as

```
public bool VerifiyPassword(string password, string salt, string validHash)
```

That function could call the Compute hash function then pass the results to Compare.
