### PR TITLE
Changed to .NET 3.5 project

### DIFF
--- a/src/Interfaces/ICryptoService.cs
+++ b/src/Interfaces/ICryptoService.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+//using System.Threading.Tasks;
 
 namespace SimpleCrypto
 {

--- a/src/PBKDF2.cs
+++ b/src/PBKDF2.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
+//using System.Threading.Tasks;
 
 namespace SimpleCrypto
 {
@@ -45,13 +45,13 @@ namespace SimpleCrypto
         /// <summary>
         /// Gets the base 64 encoded string of the hashed PlainText
         /// </summary>
-        public string HashedText 
+        public string HashedText
         { get; private set; }
 
         /// <summary>
         /// Gets or sets the salt that will be used in computing the HashedText. This contains both Salt and HashIterations.
         /// </summary>
-        public string Salt 
+        public string Salt
         { get; set; }
 
 
@@ -67,9 +67,9 @@ namespace SimpleCrypto
             if (string.IsNullOrEmpty(PlainText)) throw new InvalidOperationException("PlainText cannot be empty");
 
             //if there is no salt, generate one
-            if(string.IsNullOrEmpty(Salt))
+            if (string.IsNullOrEmpty(Salt))
                 GenerateSalt();
-            
+
             HashedText = calculateHash(HashIterations);
 
             return HashedText;
@@ -184,13 +184,11 @@ namespace SimpleCrypto
             //convert the salt into a byte array
             byte[] saltBytes = Encoding.UTF8.GetBytes(Salt);
 
-            using (var pbkdf2 = new Rfc2898DeriveBytes(PlainText, saltBytes, iteration))
-            {
-                var key = pbkdf2.GetBytes(64);
-                return Convert.ToBase64String(key);
-            }
+            var pbkdf2 = new Rfc2898DeriveBytes(PlainText, saltBytes, iteration);
+            var key = pbkdf2.GetBytes(64);
+            return Convert.ToBase64String(key);
         }
-        
+
         private void expandSalt()
         {
             try
@@ -200,9 +198,9 @@ namespace SimpleCrypto
 
                 //Get the hash iteration from the first index
                 HashIterations = int.Parse(Salt.Substring(0, i), System.Globalization.NumberStyles.Number);
-                
+
             }
-            catch(Exception)
+            catch (Exception)
             {
                 throw new FormatException("The salt was not in an expected format of {int}.{string}");
             }
@@ -222,7 +220,7 @@ namespace SimpleCrypto
             int min_length = Math.Min(passwordHash1.Length, passwordHash2.Length);
             int result = 0;
 
-            for(int i = 0; i < min_length; i++)
+            for (int i = 0; i < min_length; i++)
                 result |= passwordHash1[i] ^ passwordHash2[i];
 
             return 0 == result;

--- a/src/SimpleCrypto.csproj
+++ b/src/SimpleCrypto.csproj
@@ -9,9 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleCrypto</RootNamespace>
     <AssemblyName>SimpleCrypto</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,19 +32,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="Interfaces\ICryptoService.cs" />
     <Compile Include="PBKDF2.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RandomPassword.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Rfc2898DeriveBytes has been part of .NET since v2.0 and therefore this
library can be made compatible with lower .NET framework runtimes.
Unfortunately the library also makes use of LINQ which requires .NET
3.5.

This commit contains the following changes:
- The target framework for the SimpleCrypto project has been changed to
  .NET Framework v3.5 (client profile).
- Unused references have been removed from the SimpleCrypto project.
- Unused using directives have been removed from the ICryptoService and
  PBKDF2 classes
- The using statement around Rfc2898DeriveBytes has been removed because
  System.Security.Cryptography.DeriveBytes doesn't implement IDisposable
  in Assembly mscorlib.dll, v2.0.50727
